### PR TITLE
Remove deprecated grammar of poetry and Add certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out/
 *.log
+cacert.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.11.1-alpine
 
 COPY cacert.pem /usr/local/share/ca-certificates/cacert.crt
-RUN cat /usr/local/share/ca-certificates/cacert.crt >> /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/usr/local/share/ca-certificates/cacert.crt
+RUN cat /usr/local/share/ca-certificates/cacert.crt >> /etc/ssl/certs/ca-certificates.crt && \
+    pip config set global.cert /usr/local/share/ca-certificates/cacert.crt
+
 RUN apk add --update --no-cache \
     curl \
     graphviz \
@@ -19,7 +22,7 @@ RUN apk del \
 WORKDIR /tmp
 COPY pyproject.toml poetry.lock ./
 RUN /root/.local/bin/poetry config virtualenvs.create false && \
-    /root/.local/bin/poetry install --no-dev && \
+    /root/.local/bin/poetry install --only main && \
     rm -rf /tmp
 
 WORKDIR /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.11.1-alpine
+
+COPY cacert.pem /usr/local/share/ca-certificates/cacert.crt
+RUN cat /usr/local/share/ca-certificates/cacert.crt >> /etc/ssl/certs/ca-certificates.crt
 RUN apk add --update --no-cache \
     curl\
     graphviz\

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,23 @@ FROM python:3.11.1-alpine
 COPY cacert.pem /usr/local/share/ca-certificates/cacert.crt
 RUN cat /usr/local/share/ca-certificates/cacert.crt >> /etc/ssl/certs/ca-certificates.crt
 RUN apk add --update --no-cache \
-    curl\
-    graphviz\
-    gcc\
-    libc-dev\
-    libffi-dev\
+    curl \
+    graphviz \
+    gcc \
+    libc-dev \
+    libffi-dev \
     ttf-freefont \
-    coreutils && \
-    curl -sSL https://raw.githubusercontent.com/python-poetry/install.python-poetry.org/42a10434ed127a5986c3a9952c75d333ac3a1f8e/install-poetry.py > install-poetry.py && \
-    echo "08a38ab8de719d4012af4d62c37ce09e84edce6e1c4da7c5ccbcade359312c8b install-poetry.py" | sha256sum -c && \
-    python install-poetry.py --version 1.3.1 && \
-    apk del \
+    coreutils
+RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN apk del \
     gcc \
     libc-dev \
     libffi-dev
+
 WORKDIR /tmp
 COPY pyproject.toml poetry.lock ./
-RUN /root/.local/bin/poetry config virtualenvs.create false &&\
-    /root/.local/bin/poetry install --no-dev &&\
+RUN /root/.local/bin/poetry config virtualenvs.create false && \
+    /root/.local/bin/poetry install --no-dev && \
     rm -rf /tmp
 
 WORKDIR /out


### PR DESCRIPTION
## Introduce certificates in the following three parts.
- Installing Linux Packages
- Install Poetry
- Install Python Package with Poetry

## Replaced Poetry grammar
- `--no-dev` -> `--only main`

## The others
- Always install the latest version of Poetry